### PR TITLE
fix: only apply changes and preparations to configured actions

### DIFF
--- a/lib/ash_rate_limiter/transformer.ex
+++ b/lib/ash_rate_limiter/transformer.ex
@@ -59,29 +59,32 @@ defmodule AshRateLimiter.Transformer do
   end
 
   defp add_change_or_preparation(entity, action, dsl) when action.type == :read,
-    do: add_preparation(entity, dsl)
+    do: add_preparation_to_action(entity, action, dsl)
 
-  defp add_change_or_preparation(entity, _action, dsl), do: add_change(entity, dsl)
+  defp add_change_or_preparation(entity, action, dsl),
+    do: add_change_to_action(entity, action, dsl)
 
-  defp add_preparation(entity, dsl) do
+  defp add_preparation_to_action(entity, action, dsl) do
     with {:ok, preparation} <-
            build_entity(Dsl, [:preparations], :prepare,
              preparation:
                {Preparation,
                 action: entity.action, limit: entity.limit, per: entity.per, key: entity.key}
            ) do
-      {:ok, add_entity(dsl, [:preparations], preparation)}
+      updated_action = %{action | preparations: [preparation | action.preparations]}
+      {:ok, replace_entity(dsl, [:actions], updated_action, &(&1.name == action.name))}
     end
   end
 
-  defp add_change(entity, dsl) do
+  defp add_change_to_action(entity, action, dsl) do
     with {:ok, change} <-
            build_entity(Dsl, [:changes], :change,
              change:
                {Change,
                 action: entity.action, limit: entity.limit, per: entity.per, key: entity.key}
            ) do
-      {:ok, add_entity(dsl, [:changes], change)}
+      updated_action = %{action | changes: [change | action.changes]}
+      {:ok, replace_entity(dsl, [:actions], updated_action, &(&1.name == action.name))}
     end
   end
 end

--- a/test/ash_rate_limiter/transformer_test.exs
+++ b/test/ash_rate_limiter/transformer_test.exs
@@ -1,0 +1,77 @@
+defmodule AshRateLimiter.TransformerTest do
+  use ExUnit.Case, async: true
+  alias Example.Post
+
+  describe "transformer behavior" do
+    test "rate limited actions are enforced", %{test: test} do
+      changeset =
+        Post
+        |> Ash.Changeset.for_create(:limited_create, %{
+          title: "Local Farmer Claims 'Space Zombie' Wrecked His Barn",
+          body: """
+          Local farmer Otis Peabody is currently under observation by doctors at
+          the County Asylum. Mr. Peabody claims he saw a flying saucer and a
+          spaceman in his barn. Investigators, after a thorough examination of the
+          barn and surroundings, have found no evidence to substantiate Mr.
+          Peabody's claims.
+          """
+        })
+
+      opts = [context: %{key: to_string(test)}]
+
+      {:ok, _} = Ash.create(changeset, opts)
+      {:ok, _} = Ash.create(changeset, opts)
+      {:ok, _} = Ash.create(changeset, opts)
+      {:error, error} = Ash.create(changeset, opts)
+
+      assert %Ash.Error.Forbidden{errors: [error]} = error
+      assert %AshRateLimiter.LimitExceeded{} = error
+    end
+
+    test "non-rate limited actions work without interference" do
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{
+          title: "Original Title",
+          body: "Original Body"
+        })
+        |> Ash.create!()
+
+      # Update many times quickly - should never be rate limited
+      Enum.each(1..10, fn i ->
+        updated_post =
+          post
+          |> Ash.Changeset.for_update(:unlimited_update, %{title: "Updated Title #{i}"})
+          |> Ash.update!()
+
+        assert updated_post.title == "Updated Title #{i}"
+      end)
+    end
+
+    test "changes are added to specific actions only" do
+      # Rate limited create action should have a change
+      limited_create_action = Ash.Resource.Info.action(Post, :limited_create)
+      assert length(limited_create_action.changes) == 1
+
+      change = hd(limited_create_action.changes)
+      assert elem(change.change, 0) == AshRateLimiter.Change
+
+      # Non-rate limited update action should have no changes
+      unlimited_update_action = Ash.Resource.Info.action(Post, :unlimited_update)
+      assert unlimited_update_action.changes == []
+    end
+
+    test "preparations are added to specific actions only" do
+      # Rate limited read action should have a preparation
+      limited_read_action = Ash.Resource.Info.action(Post, :limited_read)
+      assert length(limited_read_action.preparations) == 1
+
+      preparation = hd(limited_read_action.preparations)
+      assert elem(preparation.preparation, 0) == AshRateLimiter.Preparation
+
+      # Non-rate limited read action should have no preparations
+      default_read_action = Ash.Resource.Info.action(Post, :read)
+      assert default_read_action.preparations == []
+    end
+  end
+end

--- a/test/support/example/post.ex
+++ b/test/support/example/post.ex
@@ -7,6 +7,7 @@ defmodule Example.Post do
 
     create :limited_create, accept: :*
     read :limited_read
+    update :unlimited_update, accept: [:title, :body]
   end
 
   rate_limit do


### PR DESCRIPTION
Fixes #38

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
